### PR TITLE
Omit specs in build

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -14,9 +14,6 @@
     ],
     "plugins": [
         "@babel/plugin-transform-arrow-functions"
-    ],
-    "ignore": [
-      "**/*.spec.js"
     ]
   }
   

--- a/babel.config.json
+++ b/babel.config.json
@@ -14,6 +14,9 @@
     ],
     "plugins": [
         "@babel/plugin-transform-arrow-functions"
+    ],
+    "ignore": [
+      "**/*.spec.js"
     ]
   }
   

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "version": "0.1.0",
   "private": false,
   "scripts": {
-    "build": "babel src --out-file dist/favicon-loader.js",
+    "build": "babel src/main.js --out-file dist/favicon-loader.js",
     "test": "jest",
     "test:watch": "jest --watch"
   },


### PR DESCRIPTION
Currently, the spec file is added to the build :grimacing: 